### PR TITLE
1.6.3b: Remove mob multi from action timer

### DIFF
--- a/complete-qs-betterment-script.user.js
+++ b/complete-qs-betterment-script.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Queslar Betterment Script
 // @namespace    https://www.queslar.com
-// @version      1.5.3
+// @version      1.5.4
 // @description  A script that lets you know more info about quests
 // @author       RiddleMeDoo
 // @include      *queslar.com*
@@ -78,7 +78,7 @@ class Script {
     
     this.catacomb = {
       villageActionSpeed: villageActionSpeedBoost,
-      actionTimerSeconds: 30 / (1 + villageActionSpeedBoost + tomes.speed / 100) / Math.max(1, 1 + tomes.multi_mob / 100),
+      actionTimerSeconds: 30 / (1 + villageActionSpeedBoost + tomes.speed / 100),
     }
   } 
 
@@ -236,6 +236,7 @@ class Script {
         this.handleCatacombPage({target: target});  
 
       } else {
+        this.updateCatacombData();
         this.catacombObserver.observe(target, {
           childList: true, subtree: true, attributes: false,
         });


### PR DESCRIPTION
# Changes
- Removes the mob multi % from the action timer
- Updates the action timer whenever the user navigates to the catacomb page